### PR TITLE
Encryption setup

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -28,3 +28,12 @@ sourceDir: "{{ .chezmoi.sourceDir }}"
 data:
   name: "{{ $name }}"
   email: "{{ $email }}"
+
+{{- /* Check if AGE_SECRET_KEY is set, fail gracefully if not */ -}}
+{{- if env "AGE_SECRET_KEY" -}}
+encryption:
+  age:
+    identity: "{{ env "AGE_SECRET_KEY" }}"
+    recipients:
+      - "{{ env "AGE_RECIPIENTS" }}"
+{{- end -}}

--- a/install.sh
+++ b/install.sh
@@ -28,3 +28,17 @@ set -- init --apply --source="${script_dir}"
 echo "Running 'chezmoi $*'" >&2
 # exec: replace current process with chezmoi
 exec "$chezmoi" "$@"
+
+# Add environment variable for age secret key
+if [ -z "${AGE_SECRET_KEY:-}" ]; then
+  echo "AGE_SECRET_KEY is not set. Please set it before running the script."
+else
+  export AGE_SECRET_KEY
+fi
+
+# Add environment variable for age recipients
+if [ -z "${AGE_RECIPIENTS:-}" ]; then
+  echo "AGE_RECIPIENTS is not set. Please set it before running the script."
+else
+  export AGE_RECIPIENTS
+fi


### PR DESCRIPTION
Fixes #1

Add encryption setup for Macbook home directory using Chezmoi and age.

* **install.sh**
  - Add environment variable `AGE_SECRET_KEY` and print message if not set.
  - Add environment variable `AGE_RECIPIENTS` and print message if not set.

* **.chezmoi.yaml.tmpl**
  - Add age encryption configuration using `AGE_SECRET_KEY` and `AGE_RECIPIENTS`.
  - Fail gracefully if `AGE_SECRET_KEY` is not set.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ssmiller25/dotfiles/issues/1?shareId=8183952c-1cde-4525-a1da-2d3a5f3e7e7c).